### PR TITLE
Improve logging

### DIFF
--- a/examples/code_examples/chunking.py
+++ b/examples/code_examples/chunking.py
@@ -2,19 +2,18 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load the 'conll2003' dataset
-dataset = load_dataset('conll2003')
+dataset = load_dataset("conll2003")
 
-# Use smaller models to test on CPU
-models = ['prajjwal1/bert-tiny',
-          'google/electra-small-discriminator',
-          'microsoft/deberta-v3-small',
-          'bert-base-uncased',
-          ]
+# Use smaller models to run on CPU
+models = [
+    "prajjwal1/bert-tiny",
+    "google/electra-small-discriminator",
+    "microsoft/deberta-v3-small",
+    "bert-base-uncased",
+]
 
 # Initialize the ranker, set labels to chunk tags
-ranker = TransformerRanker(dataset=dataset,
-                           dataset_downsample=0.2,
-                           label_column='chunk_tags')
+ranker = TransformerRanker(dataset=dataset, dataset_downsample=0.2, label_column="chunk_tags")
 
 # ... and run it
 result = ranker.run(models=models, batch_size=64)

--- a/examples/code_examples/classification.py
+++ b/examples/code_examples/classification.py
@@ -2,21 +2,23 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load and inspect the 'trec' dataset
-dataset = load_dataset('trec')
+dataset = load_dataset("trec")
 print(dataset)
 
 # Use smaller models to run on CPU
-language_models = ['prajjwal1/bert-tiny',
-                   'google/electra-small-discriminator',
-                   'microsoft/deberta-v3-small',
-                   'bert-base-uncased',
-                   ]
+language_models = [
+    "prajjwal1/bert-tiny",
+    "google/electra-small-discriminator",
+    "microsoft/deberta-v3-small",
+    "bert-base-uncased",
+]
 
 # Initialize the ranker
-ranker = TransformerRanker(dataset=dataset,
-                           dataset_downsample=0.2,
-                           label_column="coarse_label",
-                           )
+ranker = TransformerRanker(
+    dataset=dataset,
+    dataset_downsample=0.2,
+    label_column="coarse_label",
+)
 
 # ... and run it
 result = ranker.run(models=language_models, batch_size=32)

--- a/examples/code_examples/entailment.py
+++ b/examples/code_examples/entailment.py
@@ -2,16 +2,17 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load 'rte' Recognizing Textual Entailment dataset
-entailment_dataset = load_dataset('glue', 'rte')
+entailment_dataset = load_dataset("glue", "rte")
 
 # Use smaller models to run on CPU
-language_models = ['prajjwal1/bert-tiny',
-                   'google/electra-small-discriminator',
-                   'microsoft/deberta-v3-small',
-                   'bert-base-uncased',
-                   ]
+language_models = [
+    "prajjwal1/bert-tiny",
+    "google/electra-small-discriminator",
+    "microsoft/deberta-v3-small",
+    "bert-base-uncased",
+]
 
-# Initialize the ranker, set text_pair_column
+# Initialize the ranker, set column for text pairs
 ranker = TransformerRanker(dataset=entailment_dataset, text_pair_column="sentence2")
 
 # ... and run it

--- a/examples/code_examples/multiple_runs.py
+++ b/examples/code_examples/multiple_runs.py
@@ -2,18 +2,18 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load a dataset, initialize the ranker
-dataset = load_dataset('trec')
+dataset = load_dataset("trec")
 ranker = TransformerRanker(dataset=dataset, dataset_downsample=0.2)
 
 # Load smaller models
-models = ['prajjwal1/bert-tiny', 'google/electra-small-discriminator']
+models = ["prajjwal1/bert-tiny", "google/electra-small-discriminator"]
 
 # ... and rank them using a large batch size
 result = ranker.run(models=models, batch_size=124)
 print(result)
 
 # Add larger models
-models = ['bert-large-cased', 'google/electra-large-discriminator']
+models = ["bert-large-cased", "google/electra-large-discriminator"]
 
 # ... and rank them using a small batch size
 result.append(ranker.run(models=models, batch_size=16))

--- a/examples/code_examples/regression.py
+++ b/examples/code_examples/regression.py
@@ -2,14 +2,15 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load a regression dataset
-regression_dataset = load_dataset('glue', 'stsb')
+regression_dataset = load_dataset("glue", "stsb")
 
-# You can test on cpu using smaller models
-models = ['prajjwal1/bert-tiny',
-          'google/electra-small-discriminator',
-          'microsoft/deberta-v3-small',
-          'bert-base-uncased',
-          ]
+# Use smaller models to run on CPU
+models = [
+    "prajjwal1/bert-tiny",
+    "google/electra-small-discriminator",
+    "microsoft/deberta-v3-small",
+    "bert-base-uncased",
+]
 
 # Initialize the ranker, set the text pair column
 ranker = TransformerRanker(dataset=regression_dataset, text_pair_column="sentence2")

--- a/examples/code_examples/tagging.py
+++ b/examples/code_examples/tagging.py
@@ -2,19 +2,18 @@ from datasets import load_dataset
 from transformer_ranker import TransformerRanker
 
 # Load the WNUT-17 NER dataset of English tweets
-dataset_ner = load_dataset('leondz/wnut_17')
+dataset_ner = load_dataset("leondz/wnut_17")
 
 # Use smaller models to test on CPU
-models = ['prajjwal1/bert-tiny',
-          'google/electra-small-discriminator',
-          'microsoft/deberta-v3-small',
-          'bert-base-uncased',
-          ]
+models = [
+    "prajjwal1/bert-tiny",
+    "google/electra-small-discriminator",
+    "microsoft/deberta-v3-small",
+    "bert-base-uncased",
+]
 
 # Initialize the ranker, set labels to ner tags
-ranker = TransformerRanker(dataset=dataset_ner,
-                           dataset_downsample=0.2,
-                           label_column='ner_tags')
+ranker = TransformerRanker(dataset=dataset_ner, dataset_downsample=0.2, label_column="ner_tags")
 
 # ... and run it
 result = ranker.run(models=models, batch_size=64)

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     url="https://github.com/flairNLP/transformer-ranker",
     install_requires=read_requirements(),
     license='MIT',
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/transformer_ranker/datacleaner.py
+++ b/transformer_ranker/datacleaner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Optional, Type, Union
 
 import datasets
 import torch
@@ -22,7 +22,7 @@ class DatasetCleaner:
         task_type: Optional[str] = None,
         text_column: Optional[str] = None,
         label_column: Optional[str] = None,
-        label_map: Optional[Dict[str, int]] = None,
+        label_map: Optional[dict[str, int]] = None,
         text_pair_column: Optional[str] = None,
     ):
         """
@@ -145,7 +145,7 @@ class DatasetCleaner:
         )
         return torch.tensor(labels)
 
-    def prepare_sentences(self, dataset: Dataset) -> List[str]:
+    def prepare_sentences(self, dataset: Dataset) -> list[str]:
         """Gather sentences in the text column."""
         return dataset[self.text_column]
 
@@ -204,7 +204,7 @@ class DatasetCleaner:
                 f"Use one of the following names for tex pair: {dataset.column_names}."
             )
 
-        def merge_texts(dataset_entry: Dict[str, str]) -> Dict[str, str]:
+        def merge_texts(dataset_entry: dict[str, str]) -> dict[str, str]:
             dataset_entry[text_column] = (
                 dataset_entry[text_column] + " [SEP] " + dataset_entry[text_pair_column]
             )
@@ -273,7 +273,7 @@ class DatasetCleaner:
     @staticmethod
     def _make_labels_categorical(
         dataset: Dataset, label_column: str
-    ) -> tuple[Dataset, Dict[str, int]]:
+    ) -> tuple[Dataset, dict[str, int]]:
         """Convert string labels to integers"""
         unique_labels = sorted(set(dataset[label_column]))
         label_map = {label: idx for idx, label in enumerate(unique_labels)}
@@ -286,7 +286,7 @@ class DatasetCleaner:
         return dataset, label_map
 
     @staticmethod
-    def _create_label_map(dataset: Dataset, label_column: str) -> Dict[str, int]:
+    def _create_label_map(dataset: Dataset, label_column: str) -> dict[str, int]:
         """Try to find feature names in a hf dataset."""
         label_names = getattr(
             getattr(dataset.features[label_column], "feature", None), "names", None
@@ -306,8 +306,8 @@ class DatasetCleaner:
 
     @staticmethod
     def _change_bio_encoding(
-        dataset: Dataset, label_column: str, label_map: Dict[str, int]
-    ) -> tuple[Dataset, Dict[str, int]]:
+        dataset: Dataset, label_column: str, label_map: dict[str, int]
+    ) -> tuple[Dataset, dict[str, int]]:
         """Remove BIO prefixes from NER labels, update the dataset, and create a new label map."""
 
         # Get unique labels without BIO prefixes and create new label map
@@ -329,7 +329,7 @@ class DatasetCleaner:
         if label_map == new_label_map:
             logger.warning(
                 "Could not remove BIO prefixes for this tagging dataset. "
-                "Please add the label map as parameter label_map: Dict[str, int] = ... manually."
+                "Please add the label map as parameter label_map: dict[str, int] = ... manually."
             )
 
         return dataset, new_label_map

--- a/transformer_ranker/embedder.py
+++ b/transformer_ranker/embedder.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import torch
 from tokenizers.pre_tokenizers import Whitespace
@@ -107,7 +107,7 @@ class Embedder:
         batch_size: int = 32,
         show_loading_bar: bool = True,
         move_embeddings_to_cpu: bool = True,
-    ) -> List[torch.Tensor]:
+    ) -> list[torch.Tensor]:
         """Split sentences into batches and embedd the full dataset"""
         if not isinstance(sentences, list):
             sentences = [sentences]
@@ -126,7 +126,7 @@ class Embedder:
 
         return embeddings
 
-    def embed_batch(self, sentences, move_embeddings_to_cpu: bool = True) -> List[torch.Tensor]:
+    def embed_batch(self, sentences, move_embeddings_to_cpu: bool = True) -> list[torch.Tensor]:
         """Embeds a batch of sentences and returns a list of sentence embeddings
         (list of word embeddings). Embeddings can be moved to cpu or kept on gpu"""
         tokenized_input = self.tokenize(sentences)
@@ -176,7 +176,7 @@ class Embedder:
 
         return sentence_embeddings
 
-    def _filter_layer_ids(self, layer_ids: str) -> List[int]:
+    def _filter_layer_ids(self, layer_ids: str) -> list[int]:
         """Transform a string with layer ids into a list of ints.
         Check if any ids are out-of-bounds of model size"""
         num_layers = self.num_transformer_layers
@@ -211,11 +211,11 @@ class Embedder:
 
         return batched_embeddings
 
-    def _pool_subwords(self, sentence_embedding, sentence_word_ids) -> List[torch.Tensor]:
+    def _pool_subwords(self, sentence_embedding, sentence_word_ids) -> list[torch.Tensor]:
         """Pool sub-word embeddings into word embeddings for a single sentence.
         Subword pooling methods: 'first', 'last', 'mean'"""
-        word_embeddings: List[torch.Tensor] = []
-        subword_embeddings: List[torch.Tensor] = []
+        word_embeddings: list[torch.Tensor] = []
+        subword_embeddings: list[torch.Tensor] = []
         previous_word_id: int = 0
 
         # Gather word-level embeddings as lists of sub-words

--- a/transformer_ranker/estimators/hscore.py
+++ b/transformer_ranker/estimators/hscore.py
@@ -12,9 +12,9 @@ class HScore:
 
     def fit(self, embeddings: torch.Tensor, labels: torch.Tensor) -> float:
         """
-        H-score intuition: Higher variance between embeddings of different classes (mean vectors for each class)
-        and lower feature redundancy (i.e. inverse of the covariance matrix for all data points)
-        lead to better transferability.
+        H-score intuition: Higher variance between embeddings of different classes
+        (mean vectors for each class) and lower feature redundancy (i.e. inverse of the covariance
+        matrix for all data points) lead to better transferability.
 
         :param embeddings: Embedding matrix of shape (num_samples, hidden_size)
         :param labels: Label vector of shape (num_samples,)
@@ -33,11 +33,11 @@ class HScore:
         cov_matrix = torch.mm(embeddings.T, embeddings) / num_samples
 
         # Compute beta and delta for the Ledoit-Wolf shrinkage
-        squared_features = embeddings ** 2
+        squared_features = embeddings**2
         emp_cov_trace = torch.sum(squared_features, dim=0) / num_samples
         mean_cov = torch.sum(emp_cov_trace) / hidden_size
         beta_ = torch.sum(torch.mm(squared_features.T, squared_features)) / num_samples
-        delta_ = torch.sum(cov_matrix ** 2)
+        delta_ = torch.sum(cov_matrix**2)
         beta = (beta_ - delta_) / (hidden_size * num_samples)
         delta = delta_ - 2.0 * mean_cov * emp_cov_trace.sum() + hidden_size * mean_cov**2
         delta /= hidden_size
@@ -51,7 +51,9 @@ class HScore:
         pinv_covf_alpha = torch.linalg.pinv(covf_alpha, rcond=1e-15)
 
         # Matrix of class-conditioned means
-        class_means = torch.zeros(num_classes, hidden_size, dtype=torch.float64, device=embeddings.device)
+        class_means = torch.zeros(
+            num_classes, hidden_size, dtype=torch.float64, device=embeddings.device
+        )
         for i, cls in enumerate(classes):
             mask = labels == cls
             class_features = embeddings[mask].mean(dim=0)

--- a/transformer_ranker/estimators/nearestneighbors.py
+++ b/transformer_ranker/estimators/nearestneighbors.py
@@ -41,7 +41,7 @@ class KNN:
 
             # Exclude self-distances by setting diagonal to a large number
             diag_indices = torch.arange(start, end, device=embeddings.device)
-            dists[diag_indices - start, diag_indices] = float('inf')
+            dists[diag_indices - start, diag_indices] = float("inf")
 
             # Indices of the k nearest neighbors for the batch
             batch_knn_indices = dists.topk(self.k, largest=False).indices

--- a/transformer_ranker/ranker.py
+++ b/transformer_ranker/ranker.py
@@ -23,29 +23,24 @@ class TransformerRanker:
         **kwargs,
     ):
         """
-        Rank language models for different NLP tasks. Embed a part of the dataset and
-        estimate embedding suitability with transferability metrics like hscore or logme.
-        Embeddings can be averaged across all layers or selected from the best-performing layer.
+        Rank language models for various NLP tasks. Extract embeddings and evaluate
+        their suitability for a dataset using metrics like hscore or logme.
+        Embeddings can be averaged across all layers or selected from the best-suited layer.
 
         :param dataset: a dataset from huggingface, containing texts and label columns.
         :param dataset_downsample: a fraction to which the dataset should be reduced.
         :param kwargs: Additional dataset-specific parameters for data cleaning.
         """
-        # Clean the original dataset and keep only needed columns
-        self.data_handler = DatasetCleaner(
+        self.data_cleaner = DatasetCleaner(
             dataset_downsample=dataset_downsample,
             text_column=text_column,
             label_column=label_column,
             **kwargs,
         )
 
-        self.dataset = self.data_handler.prepare_dataset(dataset)
-
-        self.task_type = self.data_handler.task_type
-
-        # Find text and label columns
-        self.text_column = self.data_handler.text_column
-        self.label_column = self.data_handler.label_column
+        # Prepare dataset, identify task category
+        self.dataset = self.data_cleaner.prepare_dataset(dataset)
+        self.task_type = self.data_cleaner.task_type
 
     def run(
         self,
@@ -59,25 +54,30 @@ class TransformerRanker:
         **kwargs,
     ):
         """
-        Load models, get embeddings, score, and rank results.
+        Load models, get embeddings, score them, and rank results.
 
         :param models: A list of model names string identifiers
         :param batch_size: The number of samples to process in each batch, defaults to 32.
-        :param estimator: Transferability metric (e.g., 'hscore', 'logme', 'knn').
-        :param layer_aggregator: Which layer to select (e.g., 'layermean', 'bestlayer').
-        :param sentence_pooling: Embedder parameter for pooling words into a sentence embedding for
-        text classification tasks. Defaults to "mean" to average of all words.
-        :param device: Device for embedding, defaults to GPU if available ('cpu', 'cuda', 'cuda:2').
-        :param gpu_estimation: Store and score embeddings on GPU for speedup.
+        :param estimator: Transferability metric: 'hscore', 'logme', 'knn'
+        :param layer_aggregator: Which layers to use 'layermean', 'bestlayer'
+        :param sentence_pooling: Pool words into a sentence embedding for text classification.
+        :param device: Device for language models ('cpu', 'cuda', 'cuda:2')
+        :param gpu_estimation: If to score embeddings on the same device (defaults to true)
         :param kwargs: Additional parameters for the embedder class (e.g. subword pooling)
         :return: Returns the sorted dictionary of model names and their scores
         """
         self._confirm_ranker_setup(estimator=estimator, layer_aggregator=layer_aggregator)
 
+        # Set device for language model embeddings and log it
+        device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        logger.info(f"Running on {device}")
+
         # Load all transformers into hf cache
         self._preload_transformers(models, device)
 
-        labels = self.data_handler.prepare_labels(self.dataset)
+        # Prepare texts and labels from the dataset
+        texts = self.data_cleaner.prepare_sentences(self.dataset)
+        labels = self.data_cleaner.prepare_labels(self.dataset)
 
         ranking_results = Result(metric=estimator)
 
@@ -102,7 +102,7 @@ class TransformerRanker:
             )
 
             embeddings = embedder.embed(
-                self.data_handler.prepare_sentences(self.dataset),
+                sentences=texts,
                 batch_size=batch_size,
                 show_loading_bar=True,
                 move_embeddings_to_cpu=not gpu_estimation,
@@ -150,7 +150,7 @@ class TransformerRanker:
                 zip(embedded_layer_ids, layer_scores)
             )
 
-            # Aggregate layer scores
+            # Layer average gives one score, bestlayer uses max of scores
             final_score = max(layer_scores) if layer_aggregator == "bestlayer" else layer_scores[0]
             ranking_results.add_score(model_name, final_score)
 
@@ -158,7 +158,7 @@ class TransformerRanker:
             result_log = f"{model_name} estimation: {final_score} ({ranking_results.metric})"
 
             if layer_aggregator == "bestlayer":
-                result_log += f", layerwise scores: {ranking_results.layerwise_scores[model_name]}"
+                result_log += f", layer scores: {ranking_results.layerwise_scores[model_name]}"
 
             logger.info(result_log)
 
@@ -166,7 +166,8 @@ class TransformerRanker:
 
     @staticmethod
     def _preload_transformers(
-        models: List[Union[str, torch.nn.Module]], device: Optional[str] = None
+        models: List[Union[str, torch.nn.Module]],
+        device: torch.device,
     ) -> None:
         """Loads all models into HuggingFace cache"""
         cached_models, download_models = [], []

--- a/transformer_ranker/ranker.py
+++ b/transformer_ranker/ranker.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import torch
 from datasets.dataset_dict import Dataset, DatasetDict
@@ -44,7 +44,7 @@ class TransformerRanker:
 
     def run(
         self,
-        models: List[Union[str, torch.nn.Module]],
+        models: list[Union[str, torch.nn.Module]],
         batch_size: int = 32,
         estimator: str = "hscore",
         layer_aggregator: str = "layermean",
@@ -166,7 +166,7 @@ class TransformerRanker:
 
     @staticmethod
     def _preload_transformers(
-        models: List[Union[str, torch.nn.Module]],
+        models: list[Union[str, torch.nn.Module]],
         device: torch.device,
     ) -> None:
         """Loads all models into HuggingFace cache"""

--- a/transformer_ranker/utils.py
+++ b/transformer_ranker/utils.py
@@ -1,12 +1,11 @@
 import logging
 import operator
 import warnings
-from typing import Dict, List
 
 from transformers import logging as transformers_logging
 
 
-def prepare_popular_models(model_size="base") -> List[str]:
+def prepare_popular_models(model_size="base") -> list[str]:
     """Two lists of language models to try out"""
     base_models = [
         # English models
@@ -100,11 +99,11 @@ class Result:
         param metric: metric name (e.g. "hscore", or "logme")
         """
         self.metric = metric
-        self._results: Dict[str, float] = {}
-        self.layerwise_scores: Dict[str, Dict[int, float]] = {}
+        self._results: dict[str, float] = {}
+        self.layerwise_scores: dict[str, dict[int, float]] = {}
 
     @property
-    def results(self) -> Dict[str, float]:
+    def results(self) -> dict[str, float]:
         """Return the result dictionary sorted by scores in descending order"""
         return dict(sorted(self._results.items(), key=lambda x: x[1], reverse=True))
 
@@ -115,12 +114,12 @@ class Result:
         return model_name
 
     @property
-    def top_three(self) -> Dict[str, float]:
+    def top_three(self) -> dict[str, float]:
         """Return three highest scoring models"""
         return {k: self.results[k] for k in list(self.results.keys())[: min(3, len(self.results))]}
 
     @property
-    def best_layers(self) -> Dict[str, int]:
+    def best_layers(self) -> dict[str, int]:
         """Return a dictionary mapping each model name to its best layer ID."""
         best_layers_dict = {}
         for model, values in self.layerwise_scores.items():


### PR DESCRIPTION
Logging should give a clear idea of what happens in the ranker.

```python3
from datasets import load_dataset
from transformer_ranker import TransformerRanker, prepare_popular_models

# Load a dataset
dataset = load_dataset('conll2003')

# Prepare some language models
language_models = prepare_popular_models('large')

# Initialize the ranker with the dataset
ranker = TransformerRanker(dataset, dataset_downsample=0.2)

# Run it with your models
results = ranker.run(language_models, batch_size=32)

# Inspect results
print(results)
```

First, the dataset is preprocessed. The logger shows the dataset info, including column names for texts and labels, the label map, dataset size, and the task category.

```console
transformer_ranker:Texts and labels: tokens, ner_tags
transformer_ranker:Label map: {'O': 0, 'ORG': 1, 'LOC': 2, 'MISC': 3, 'PER': 4}
transformer_ranker:Dataset size: 4148 texts (down-sampled to 0.2)
transformer_ranker:Task category: token classification
transformer_ranker:Running on cuda:0
transformer_ranker:Models found in cache: ['bert-large-uncased', 'roberta-large', ..., 'KISTI-AI/scideberta']

```

Second, the models are downloaded or loaded from cache. This stage can take the majority of the time.

Third, the ranking starts. Each model has two loading bars: (1) one for embedding texts (2) one for scoring embeddings with a transferability metric. 

```console
Retrieving Embeddings: 100%|██████████| 130/130 [00:12<00:00, 10.75it/s]
Transferability Score: 100%|██████████| 1/1 [00:00<00:00,  2.74it/s]
transformer_ranker:bert-large-uncased estimation: 2.6677 (hscore)
Retrieving Embeddings: 100%|██████████| 130/130 [00:12<00:00, 10.63it/s]
Transferability Score: 100%|██████████| 1/1 [00:00<00:00,  2.62it/s]
transformer_ranker:roberta-large estimation: 2.7269 (hscore)
Retrieving Embeddings: 100%|██████████| 130/130 [00:11<00:00, 11.01it/s]
Transferability Score: 100%|██████████| 1/1 [00:00<00:00,  1.38it/s]
transformer_ranker:google/electra-large-discriminator estimation: 2.7463 (hscore)
...
```

Finally, the results can be printed out:

```console
Rank 1. microsoft/deberta-v3-large: 2.7883
...
Rank 11. dmis-lab/biobert-large-cased-v1.1: 1.7927
```

Improvements made to the logging:
- Log the device.
- Add the label map to the log.
- Add metric names next to scores.

Other changes:
- Use Python 3.9 typing.
- Use consistent double quotes.


