### PR TITLE
Support encoder-decoder models (BART, T5)

### DIFF
--- a/transformer_ranker/embedder.py
+++ b/transformer_ranker/embedder.py
@@ -95,7 +95,7 @@ class Embedder:
             if hasattr(outputs, "hidden_states"):
                 hidden_states = outputs.hidden_states
             else:
-                raise ValueError(f"Failed to get hidden states from model: {self.name}")
+                raise ValueError(f"Failed to get hidden states for model: {self.name}")
 
         # Exclude the embedding layer (index 0)
         embeddings = torch.stack(hidden_states[1:], dim=0)
@@ -131,7 +131,9 @@ class Embedder:
             else AutoModel.from_pretrained(model, local_files_only=local_files_only)
         )
 
-        self.model = getattr(self.model, "encoder", self.model)  # set to encoder for encoder-decoder models
+        if hasattr(self.model.config, 'is_encoder_decoder') and self.model.config.is_encoder_decoder:
+            self.model = self.model.encoder  # remove decoder
+
         self.name = getattr(self.model.config, "name_or_path", "Unknown Model")
 
     def _setup_tokenizer(self, tokenizer: Optional[Union[str, PreTrainedTokenizerFast]]) -> None:


### PR DESCRIPTION
Adds support for encoder-decoder models by extracting hidden states from the encoder only. This unlocks [BART](https://huggingface.co/facebook/bart-base), [T5](https://huggingface.co/google-t5/t5-base), [CodeT5](https://huggingface.co/Salesforce/codet5-base), [StarCoder](https://huggingface.co/bigcode/starcoderbase-1b) and similar models. 

Tested with bart-base and t5-base, the snippet from #8 now runs as expected.